### PR TITLE
Fix wrong return values

### DIFF
--- a/include/fst.hpp
+++ b/include/fst.hpp
@@ -290,8 +290,20 @@ FST::Iter FST::moveToLeftmostKeyStartingAtNode(level_t level, size_t node_number
   FST::Iter iter(this);
 
   if (level < getSparseStartLevel()) { // starting in dense part
-    // todo implement me
-    throw NotYetImplemented("move to leftmos key in dense + sparse iterator");
+    iter.dense_iter_.setToFirstLabelInNode(node_number, level);
+    iter.dense_iter_.moveToLeftMostKey();
+
+    assert (iter.dense_iter_.isValid());
+    if (iter.dense_iter_.isComplete()) return iter;
+
+    // todo what does isSearchComplete mean here for dense iterator?
+
+    // hand over to sparse iterator
+    if (!iter.dense_iter_.isMoveLeftComplete()) {
+      iter.passToSparse();
+      iter.sparse_iter_.moveToLeftMostKey();
+      return iter;
+    }
   } else { // directly start in sparse levels
     iter.dense_iter_.skip(); // skip the dense levels
     iter.sparse_iter_.setStartNodeNum(node_number);
@@ -308,6 +320,7 @@ FST::Iter FST::moveToKeyStartingAtNode(level_t &level,
 
   if (level < getSparseStartLevel()) { // starting in dense part
     // handle dense levels
+//    louds_dense_->
     louds_dense_->moveToKeyGreaterThanStartingNodeNumber(node_number, level, key, true, iter.dense_iter_);
     if (!iter.dense_iter_.isValid()) return iter;
     if (iter.dense_iter_.isComplete()) return iter;

--- a/include/fst.hpp
+++ b/include/fst.hpp
@@ -70,16 +70,15 @@ class FST {
   }
 
   FST(const std::vector<uint32_t> &offsets, const std::vector<uint64_t> &values, const uint8_t *data) {
-    std::vector<std::string> transformed_keys;
-    transformed_keys.reserve(offsets.size());
+    keys_.reserve(offsets.size());
 
     for (auto offset: offsets) {
       uint8_t key_length = data[offset];
       std::string key(reinterpret_cast<const char*>(data) + offset + 1, key_length);
-      transformed_keys.emplace_back(move(key));
+      keys_.emplace_back(move(key));
     }
 
-    create(transformed_keys, values, kIncludeDense, kSparseDenseRatio);
+    create(keys_, values, kIncludeDense, kSparseDenseRatio);
   }
 
   FST(const std::vector<uint64_t> &keys, const std::vector<uint64_t> &values) {
@@ -174,6 +173,7 @@ class FST {
   }
 
  private:
+  std::vector<std::string> keys_;
   std::unique_ptr<LoudsSparse> louds_sparse_;
   std::unique_ptr<FSTBuilder> builder_;
   std::unique_ptr<LoudsDense> louds_dense_;

--- a/include/fst.hpp
+++ b/include/fst.hpp
@@ -133,6 +133,8 @@ class FST {
 
   uint64_t lookupNodeNum(const char *key, uint64_t key_length) const;
 
+  std::pair<bool, uint64_t> lookupNodeNumOption(const char *key, uint64_t key_length) const;
+
   void moveToLeftmostKeyStartingAtNode(level_t level, size_t node_number, FST::Iter& iter) const;
 
   FST::Iter moveToKeyStartingAtNode(level_t &level, size_t node_number, const std::string &key) const;
@@ -236,7 +238,15 @@ uint64_t FST::lookupNodeNum(const char *key, uint64_t key_length) const {
   if (louds_dense_->lookupNodeNumber(key, key_length, node_num))
     if (key_length >= louds_sparse_->getStartLevel()) louds_sparse_->lookupNodeNumber(key, key_length, node_num);
   return node_num;
-};
+}
+
+std::pair<bool, uint64_t> FST::lookupNodeNumOption(const char *key, uint64_t key_length) const {
+  position_t node_num = 0;
+  if (!louds_dense_->lookupNodeNumberOption(key, key_length, node_num)) return {false, UINT64_MAX};
+  if (key_length < louds_sparse_->getStartLevel()) return {false, UINT64_MAX};
+  if (louds_sparse_->lookupNodeNumberOption(key, key_length, node_num)) return {true, node_num};
+  return {false, UINT64_MAX};
+}
 
 inline bool FST::lookupKeyAtNode(const char *key, uint64_t key_length, level_t level, size_t node_number,
                                  uint64_t &value) const {

--- a/include/fst_builder.hpp
+++ b/include/fst_builder.hpp
@@ -64,9 +64,9 @@ class FSTBuilder {
   const std::vector<position_t> &getNodeCounts() const { return node_counts_; }
   level_t getSparseStartLevel() const { return sparse_start_level_; }
 
-  std::vector<uint64_t> getDenseOffsets() const { return positions_dense_; }
+  std::vector<uint64_t> getDenseValues() const { return values_dense_; }
 
-  std::vector<uint64_t> getSparseOffsets() const { return positions_sparse_; }
+  std::vector<uint64_t> getSparseValues() const { return values_sparse_; }
 
  private:
   static bool isSameKey(const std::string &a, const std::string &b) {
@@ -132,19 +132,19 @@ class FSTBuilder {
   uint32_t sparse_dense_ratio_{};
   level_t sparse_start_level_;
 
-  std::vector<std::vector<uint64_t>> positions_;
+  std::vector<std::vector<uint64_t>> values_;
 
   // LOUDS-Sparse bit/byte vectors
   std::vector<std::vector<label_t>> labels_;
   std::vector<std::vector<word_t>> child_indicator_bits_;
   std::vector<std::vector<word_t>> louds_bits_;
-  std::vector<uint64_t> positions_sparse_;
+  std::vector<uint64_t> values_sparse_;
 
   // LOUDS-Dense bit vectors
   std::vector<std::vector<word_t>> bitmap_labels_;
   std::vector<std::vector<word_t>> bitmap_child_indicator_bits_;
   std::vector<std::vector<word_t>> prefixkey_indicator_bits_;
-  std::vector<uint64_t> positions_dense_;
+  std::vector<uint64_t> values_dense_;
 
   // auxiliary per level bookkeeping vectors
   std::vector<position_t> node_counts_;
@@ -168,10 +168,10 @@ void FSTBuilder::buildSparse(const std::vector<std::string> &keys,
     position_t curpos = i;
     while ((i + 1 < keys.size()) && isSameKey(keys[curpos], keys[i + 1])) i++;
     if (i < keys.size() - 1)
-      insertKeyBytesToTrieUntilUnique(keys[curpos], curpos, keys[i + 1],
+      insertKeyBytesToTrieUntilUnique(keys[curpos], values[curpos], keys[i + 1],
                                       level);
     else  // for last key, there is no successor key in the list
-      insertKeyBytesToTrieUntilUnique(keys[curpos], curpos, std::string(),
+      insertKeyBytesToTrieUntilUnique(keys[curpos], values[curpos], std::string(),
                                       level);
   }
 }
@@ -188,7 +188,7 @@ level_t FSTBuilder::skipCommonPrefix(const std::string &key) {
 
 level_t FSTBuilder::insertKeyBytesToTrieUntilUnique(
     const std::string &key,
-    const uint64_t position,
+    const uint64_t value,
     const std::string &next_key,
     const level_t start_level) {
   assert(start_level < key.length());
@@ -208,7 +208,7 @@ level_t FSTBuilder::insertKeyBytesToTrieUntilUnique(
 
   if (level > next_key.length()
       || !isSameKey(key.substr(0, level), next_key.substr(0, level))) {
-    positions_[level - 1].emplace_back(position);
+    values_[level - 1].emplace_back(value);
     return level;
   }
 
@@ -220,7 +220,7 @@ level_t FSTBuilder::insertKeyBytesToTrieUntilUnique(
     insertKeyByte(key[level], level, is_start_of_node, is_term);
     level++;
   }
-  positions_[level - 1].emplace_back(position);
+  values_[level - 1].emplace_back(value);
   return level;
 }
 
@@ -280,16 +280,16 @@ inline void FSTBuilder::determineCutoffLevel() {
 
   // CA build dense and sparse values vectors
   for (uint64_t level = 0; level < sparse_start_level_; level++) {
-    positions_dense_.insert(positions_dense_.end(), positions_[level].begin(),
-                            positions_[level].end());
+    values_dense_.insert(values_dense_.end(), values_[level].begin(),
+                            values_[level].end());
   }
 
-  for (uint64_t level = sparse_start_level_; level < positions_.size();
+  for (uint64_t level = sparse_start_level_; level < values_.size();
        level++) {
-    positions_sparse_.insert(positions_sparse_.end(), positions_[level].begin(),
-                             positions_[level].end());
+    values_sparse_.insert(values_sparse_.end(), values_[level].begin(),
+                             values_[level].end());
   }
-  positions_.clear();
+  values_.clear();
 }
 
 inline uint64_t FSTBuilder::computeDenseMem(const level_t downto_level) const {
@@ -359,7 +359,7 @@ void FSTBuilder::setLabelAndChildIndicatorBitmap(const level_t level,
 
 void FSTBuilder::addLevel() {
   labels_.emplace_back(std::vector<label_t>());
-  positions_.emplace_back(std::vector<uint64_t>());
+  values_.emplace_back(std::vector<uint64_t>());
   child_indicator_bits_.emplace_back(std::vector<word_t>());
   louds_bits_.emplace_back(std::vector<word_t>());
 

--- a/include/louds_dense.hpp
+++ b/include/louds_dense.hpp
@@ -573,8 +573,20 @@ position_t LoudsDense::getPrevPos(const position_t pos,
 
 void LoudsDense::Iter::clear() {
   is_valid_ = false;
+  is_search_complete_ = false;
+  is_move_left_complete_ = false;
+  is_move_right_complete_ = false;
+  send_out_node_num_ = 0;
   key_len_ = 0;
   is_at_prefix_key_ = false;
+  is_skipped_ = false;
+  skipped_ht_levels_ = 0;
+
+  std::fill(key_.begin(), key_.end(), 0);
+  std::fill(pos_in_trie_.begin(), pos_in_trie_.end(), 0);
+  std::fill(value_pos_.begin(), value_pos_.end(), 0);
+  std::fill(value_pos_initialized_.begin(), value_pos_initialized_.end(), false);
+
 }
 
 int LoudsDense::Iter::compare(const std::string &key) const {

--- a/include/louds_dense.hpp
+++ b/include/louds_dense.hpp
@@ -37,12 +37,12 @@ class LoudsDense {
           is_at_prefix_key_(false),
           is_skipped_(false),
           skipped_ht_levels_(0) {
-      for (level_t level = 0; level < trie_->getHeight(); level++) {
-        key_.push_back(0);
-        pos_in_trie_.push_back(0);
-        value_pos_.push_back(0);
-        value_pos_initialized_.push_back(false);
-      }
+
+        const auto height = trie_->getHeight();
+        key_.resize(height, 0);
+        pos_in_trie_.resize(height, 0);
+        value_pos_.resize(height, 0);
+        value_pos_initialized_.resize(height, false);
     }
 
     void clear();

--- a/include/louds_sparse.hpp
+++ b/include/louds_sparse.hpp
@@ -564,7 +564,15 @@ bool LoudsSparse::compareSuffixGreaterThan(const position_t pos,
 void LoudsSparse::Iter::clear() {
   is_valid_ = false;
   key_len_ = 0;
+  start_node_num_ = 0;
+  key_len_ = 0;
   is_at_terminator_ = false;
+  start_level_ = trie_->getStartLevel();
+
+  std::fill(key_.begin(), key_.end(), 0);
+  std::fill(pos_in_trie_.begin(), pos_in_trie_.end(), 0);
+  std::fill(value_pos_.begin(), value_pos_.end(), 0);
+  std::fill(value_pos_initialized_.begin(), value_pos_initialized_.end(), false);
 }
 
 int LoudsSparse::Iter::compare(const std::string &key) const {

--- a/include/louds_sparse.hpp
+++ b/include/louds_sparse.hpp
@@ -30,12 +30,11 @@ class LoudsSparse {
           key_len_(0),
           is_at_terminator_(false) {
       start_level_ = trie_->getStartLevel();
-      for (level_t level = start_level_; level < trie_->getHeight(); level++) {
-        key_.push_back(0);
-        pos_in_trie_.push_back(0);
-        value_pos_.push_back(0);
-        value_pos_initialized_.push_back(false);
-      }
+      const auto height = trie_->getHeight() - start_level_;
+      key_.resize(height, 0);
+      pos_in_trie_.resize(height, 0);
+      value_pos_.resize(height, 0);
+      value_pos_initialized_.resize(height, false);
     }
 
     void clear();

--- a/include/louds_sparse.hpp
+++ b/include/louds_sparse.hpp
@@ -116,6 +116,8 @@ class LoudsSparse {
 
   void lookupNodeNumber(const char *key, uint64_t key_length, position_t &out_node_num) const;
 
+  bool lookupNodeNumberOption(const char *key, uint64_t key_length, position_t &out_node_num) const;
+
   void moveToKeyGreaterThan(const std::string &searched_key, bool inclusive, level_t level,
                             LoudsSparse::Iter &iter) const;
 
@@ -373,6 +375,19 @@ void LoudsSparse::lookupNodeNumber(const char *key, uint64_t key_length, positio
     node_num = getChildNodeNum(pos);
     pos = getFirstLabelPos(node_num);
   }
+}
+
+bool LoudsSparse::lookupNodeNumberOption(const char *key, uint64_t key_length, position_t &node_num) const {
+  position_t pos = getFirstLabelPos(node_num);
+
+  for (uint64_t level = start_level_; level < key_length; level++) {
+    bool found_label = labels_->search((label_t) key[level], pos, nodeSize(pos));
+    if (!found_label || !child_indicator_bits_->readBit(pos)) return false;
+    // move to child
+    node_num = getChildNodeNum(pos);
+    pos = getFirstLabelPos(node_num);
+  }
+  return true;
 }
 
 void LoudsSparse::moveToKeyGreaterThan(const std::string &searched_key,

--- a/include/louds_sparse.hpp
+++ b/include/louds_sparse.hpp
@@ -103,10 +103,10 @@ class LoudsSparse {
   // point query: trie walk starts at node "in_node_num" instead of root
   // in_node_num is provided by louds-dense's lookupKey function
   bool lookupKey(const std::string &key, position_t in_node_num,
-                 uint64_t &offset) const;
+                 uint64_t &value) const;
 
   bool lookupKeyAtNode(const char *key, uint64_t key_length, position_t in_node_num,
-                       uint64_t &offset, uint64_t level) const;
+                       uint64_t &value, uint64_t level) const;
 
   bool findNextNodeOrValue(const char keyByte, size_t &node_number) const;
 
@@ -193,7 +193,7 @@ class LoudsSparse {
   static const position_t kRankBasicBlockSize = 512;
   static const position_t kSelectSampleInterval = 64;
 
-  std::vector<uint64_t> positions_sparse_;
+  std::vector<uint64_t> values_sparse_;
 
   level_t height_;       // trie height
   level_t start_level_;  // louds-sparse encoding starts at this level
@@ -247,12 +247,12 @@ LoudsSparse::LoudsSparse(const FSTBuilder *builder,
                                                   start_level_,
                                                   height_);
 
-  positions_sparse_ = builder->getSparseOffsets();
+  values_sparse_ = builder->getSparseValues();
 }
 
 bool LoudsSparse::lookupKey(const std::string &key,
                             const position_t in_node_num,
-                            uint64_t &offset) const {
+                            uint64_t &value) const {
   position_t node_num = in_node_num;
   position_t pos = getFirstLabelPos(node_num);
   level_t level = 0;
@@ -266,7 +266,7 @@ bool LoudsSparse::lookupKey(const std::string &key,
     // if trie branch terminates
     if (!child_indicator_bits_->readBit(pos)) {
       uint64_t value_pos = pos - child_indicator_bits_->rank(pos);
-      offset = positions_sparse_[value_pos];
+      value = values_sparse_[value_pos];
       //this check must be performed from the caller
       // return (*keys_)[value] == key;
       return true;
@@ -280,7 +280,7 @@ bool LoudsSparse::lookupKey(const std::string &key,
 }
 
 inline bool LoudsSparse::lookupKeyAtNode(const char *key, uint64_t key_length, position_t in_node_num,
-                                         uint64_t &offset, uint64_t level) const {
+                                         uint64_t &value, uint64_t level) const {
   position_t node_num = in_node_num;
   position_t pos = getFirstLabelPos(node_num);
   for (; level < key_length; level++) {
@@ -293,7 +293,7 @@ inline bool LoudsSparse::lookupKeyAtNode(const char *key, uint64_t key_length, p
     // if trie branch terminates
     if (!child_indicator_bits_->readBit(pos)) {
       uint64_t value_pos = pos - child_indicator_bits_->rank(pos);
-      offset = positions_sparse_[value_pos];
+      value = values_sparse_[value_pos];
       //this check must be performed from the caller
       // return (*keys_)[value] == key;
       return true;
@@ -322,8 +322,8 @@ bool LoudsSparse::findNextNodeOrValue(const char keyByte, size_t &node_num) cons
   // find next node or value
   if (!child_indicator_bits_->readBit(pos)) { // branch terminates
     uint64_t value_pos = pos - child_indicator_bits_->rank(pos);
-    uint64_t offset = positions_sparse_[value_pos];
-    node_num = (offset << 2u) | 1u;
+    uint64_t value = values_sparse_[value_pos];
+    node_num = (value << 2u) | 1u;
   } else { // branch continues
     node_num = (getChildNodeNum(pos) << 2u) | 3u;
   }
@@ -340,8 +340,8 @@ void LoudsSparse::getNode(size_t nodeNumber, std::vector<uint8_t> &labels, std::
       values.emplace_back(childNodeNum << 2U | 3U);
     } else { // leads to a value
       uint64_t value_pos = i - child_indicator_bits_->rank(i);
-      auto offset = positions_sparse_[value_pos];
-      values.emplace_back(offset << 2U | 1U);
+      auto value = values_sparse_[value_pos];
+      values.emplace_back(value << 2U | 1U);
     }
   }
 }
@@ -499,7 +499,7 @@ uint64_t LoudsSparse::serializedSize() const {
 
 uint64_t LoudsSparse::getMemoryUsage() const {
   return (sizeof(*this) + labels_->size() + child_indicator_bits_->size() +
-      louds_bits_->size() + positions_sparse_.size() * 8);
+      louds_bits_->size() + values_sparse_.size() * 8);
 }
 
 position_t LoudsSparse::getChildNodeNum(const position_t pos) const {
@@ -702,7 +702,7 @@ void LoudsSparse::Iter::moveToRightMostKey() {
 }
 
 uint64_t LoudsSparse::Iter::getValue() const {
-  return trie_->positions_sparse_[value_pos_[key_len_ - 1]];
+  return trie_->values_sparse_[value_pos_[key_len_ - 1]];
 }
 
 uint64_t LoudsSparse::Iter::getLastIteratorPosition() const {


### PR DESCRIPTION
Fix bug where the FST Builder used the index into the values vector instead of the actual value and therefore returned wrong values when the invariant `index == values[index]` was not given.
Also fix misleading naming of variables.
Moreover, enable the lookup of node nums with an optional result, i.e. `std::pair{false, UINT64_MAX}` when no node num for key is found.